### PR TITLE
Improve Airtable error handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -478,9 +478,18 @@
         },
         body: JSON.stringify(veri)
       });
-      
+
       if (!yanit.ok) {
-        throw new Error(`HTTP ${yanit.status}`);
+        let detay = "";
+        try {
+          const errJson = await yanit.json();
+          if (errJson.error && errJson.error.message) {
+            detay = " - " + errJson.error.message;
+          }
+        } catch (e) {
+          // JSON parse hatası varsa detay ekleme
+        }
+        throw new Error(`HTTP ${yanit.status}${detay}`);
       }
     }
     


### PR DESCRIPTION
## Summary
- handle Airtable API error details so HTTP 422 returns helpful messages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6886738677f0832b92f07a82ca80fe2c