### PR TITLE
Proxy Airtable access through Netlify function

### DIFF
--- a/index.html
+++ b/index.html
@@ -291,18 +291,6 @@
     <div id="ayarlar" class="tab-content">
       <h2>Sistem Ayarları</h2>
       
-      <div class="form-section">
-        <div class="form-group">
-          <label>Airtable API Token:</label>
-          <input type="password" id="api-token" placeholder="Token giriniz">
-        </div>
-        
-        <div class="form-group">
-          <label>Base ID:</label>
-          <input type="text" id="base-id" placeholder="Base ID giriniz">
-        </div>
-      </div>
-      
       <div class="email-status">
         <h3>📧 E-posta Rapor Sistemi</h3>
         <p><strong>Gönderim Adresi:</strong> <span id="email-alici"></span></p>
@@ -311,9 +299,8 @@
         <p><strong>Sonraki Gönderim:</strong> <span id="sonraki-email-tarihi">-</span></p>
         <button class="btn btn-secondary" onclick="testEmailGonder()">📧 Test E-posta Gönder</button>
       </div>
-      
+
       <div style="text-align: center;">
-        <button class="btn" onclick="ayarlariKaydet()">💾 Ayarları Kaydet</button>
         <button class="btn btn-secondary" onclick="verileriYedekle()">💾 Veri Yedekle</button>
       </div>
       
@@ -334,7 +321,6 @@
   <script>
     // Sabitler ve yapılandırma
     const CONFIG = {
-      TOKEN: "process.env.AIRTABLE_PAT",
       EMAIL_API_URL: "https://api.emailjs.com/api/v1.0/email/send", // EmailJS API
       EMAIL_SERVICE_ID: "service_sut_takip", // EmailJS Service ID
       EMAIL_TEMPLATE_ID: "template_15gun_rapor", // EmailJS Template ID
@@ -459,7 +445,7 @@
     // Airtable kayıt fonksiyonu
     async function airtableKaydet(formData) {
       const { baseId, tablo } = CONFIG.TABLO_YAPISI[formData.koy];
-      const url = `https://api.airtable.com/v0/${baseId}/${encodeURIComponent(tablo)}`;
+      const url = `/.netlify/functions/airtable?baseId=${baseId}&table=${encodeURIComponent(tablo)}`;
       
       const veri = {
         records: [{
@@ -478,7 +464,6 @@
       const yanit = await fetch(url, {
         method: "POST",
         headers: {
-          "Authorization": "Bearer " + CONFIG.TOKEN,
           "Content-Type": "application/json"
         },
         body: JSON.stringify(veri)
@@ -745,16 +730,6 @@ Sistem: https://your-domain.netlify.app
       return response;
     }
     
-    // Ayarları kaydet
-    function ayarlariKaydet() {
-      const apiToken = document.getElementById("api-token").value;
-      const baseId = document.getElementById("base-id").value;
-      
-      if (apiToken) localStorage.setItem('airtable-token', apiToken);
-      if (baseId) localStorage.setItem('airtable-base', baseId);
-      
-      gosterMesaj("Ayarlar kaydedildi.", "success");
-    }
     
     // Veri yedekleme
     function verileriYedekle() {

--- a/netlify/functions/airtable.js
+++ b/netlify/functions/airtable.js
@@ -1,0 +1,51 @@
+exports.handler = async function(event) {
+  const { httpMethod, queryStringParameters } = event;
+  const { baseId, table, recordId, offset, pageSize } = queryStringParameters;
+
+  if (!baseId || !table) {
+    return {
+      statusCode: 400,
+      body: JSON.stringify({ error: 'baseId and table are required' })
+    };
+  }
+
+  let url = `https://api.airtable.com/v0/${baseId}/${encodeURIComponent(table)}`;
+  if (recordId) {
+    url += `/${recordId}`;
+  }
+
+  const params = new URLSearchParams();
+  if (offset) params.append('offset', offset);
+  if (pageSize) params.append('pageSize', pageSize);
+  const qs = params.toString();
+  if (qs) url += `?${qs}`;
+
+  const init = {
+    method: httpMethod,
+    headers: {
+      'Authorization': `Bearer ${process.env.AIRTABLE_PAT}`,
+      'Content-Type': 'application/json'
+    }
+  };
+
+  if (httpMethod !== 'GET' && httpMethod !== 'HEAD') {
+    init.body = event.body;
+  }
+
+  try {
+    const resp = await fetch(url, init);
+    const text = await resp.text();
+    return {
+      statusCode: resp.status,
+      headers: {
+        'Content-Type': resp.headers.get('content-type') || 'application/json'
+      },
+      body: text
+    };
+  } catch (err) {
+    return {
+      statusCode: 500,
+      body: JSON.stringify({ error: err.message })
+    };
+  }
+};

--- a/raporlar.html
+++ b/raporlar.html
@@ -354,7 +354,6 @@
     let siralamaDurumu = { alan: '', yön: 'asc' };
 
     const CONFIG = {
-      TOKEN: "patdVebxph6wUC9cY.44985211c25b8626cd608646e1743983af02c953253bdc4de61297a8ba174f63",
       TABLO_YAPISI: {
         "Yuvalı": { baseId: "appngTzrsiNEo3rIN", tablo: "Tablo1" },
         "Karapürçek": { baseId: "appngTzrsiNEo3rIN", tablo: "Tablo2" },
@@ -388,10 +387,8 @@
         for (const [koy, { baseId, tablo }] of Object.entries(CONFIG.TABLO_YAPISI)) {
           let offset = "";
           do {
-            const url = `https://api.airtable.com/v0/${baseId}/${encodeURIComponent(tablo)}?pageSize=100${offset ? `&offset=${offset}` : ""}`;
-            const yanit = await fetch(url, {
-              headers: { "Authorization": "Bearer " + CONFIG.TOKEN }
-            });
+            const url = `/.netlify/functions/airtable?baseId=${baseId}&table=${encodeURIComponent(tablo)}&pageSize=100${offset ? `&offset=${offset}` : ""}`;
+            const yanit = await fetch(url);
             const data = await yanit.json();
             data.records.forEach(rec => {
               const f = rec.fields;
@@ -589,10 +586,9 @@
       const { baseId, tablo } = CONFIG.TABLO_YAPISI[mevcut.koy] || {};
       if (!baseId || !tablo) return;
       try {
-        await fetch(`https://api.airtable.com/v0/${baseId}/${encodeURIComponent(tablo)}/${recId}`, {
+        await fetch(`/.netlify/functions/airtable?baseId=${baseId}&table=${encodeURIComponent(tablo)}&recordId=${recId}`, {
           method: 'PATCH',
           headers: {
-            'Authorization': 'Bearer ' + CONFIG.TOKEN,
             'Content-Type': 'application/json'
           },
           body: JSON.stringify({ fields: { [ogunAlan]: yeniMiktar } })

--- a/service-worker.js
+++ b/service-worker.js
@@ -13,7 +13,7 @@ const urlsToCache = [
 
 // API endpoint'leri
 const API_ENDPOINTS = [
-  "https://api.airtable.com"
+  self.location.origin + "/.netlify/functions/airtable"
 ];
 
 // Service Worker kurulumu


### PR DESCRIPTION
## Summary
- add Netlify function that proxies Airtable requests using server-side token
- route frontend Airtable calls through the new function and drop client token usage
- update service worker to recognise the new proxy endpoint
- remove obsolete Airtable token and base ID settings from the frontend

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b0402d664832bbb687a9c99475217