### PR TITLE
Centralize Airtable base ID in proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,18 +87,14 @@ sut-takip-sistemi/
 ## ⚙️ Yapılandırma
 
 ### Airtable API Ayarları
-1. `index.html` dosyasındaki API token'ı güncelleyin:
-```javascript
-const CONFIG = {
-  TOKEN: "your_airtable_token_here",
-  // ...
-};
-```
+1. Netlify panelinde aşağıdaki ortam değişkenlerini tanımlayın:
+   - `AIRTABLE_PAT`: Airtable Personal Access Token
+   - `AIRTABLE_BASE_ID`: Airtable Base ID (ör. `appngTzrsiNEo3rIN`)
 
-2. Base ID ve tablo isimlerini kontrol edin:
+2. `index.html` ve `raporlar.html` dosyalarında yalnızca tablo adlarını tanımlayın:
 ```javascript
 TABLO_YAPISI: {
-  "Köy 1": { baseId: "your_base_id", tablo: "your_table_name" }
+  "Köy 1": { tablo: "your_table_name" }
   // ...
 }
 ```
@@ -115,7 +111,7 @@ Netlify'de custom domain ayarlamak için:
 Hassas bilgileri Netlify environment variables ile saklayın:
 1. Site Settings > Environment variables
 2. Yeni variable ekleyin:
-   - `AIRTABLE_TOKEN`
+   - `AIRTABLE_PAT`
    - `AIRTABLE_BASE_ID`
 
 ### HTTPS

--- a/index.html
+++ b/index.html
@@ -327,10 +327,10 @@
       EMAIL_USER_ID: "your_emailjs_user_id", // EmailJS User ID
       EMAIL_RECIPIENT: "saraysut-59@hotmail.com.tr", // Rapor gönderim adresi
       TABLO_YAPISI: {
-        "Yuvalı": { baseId: "appngTzrsiNEo3rIN", tablo: "Tablo1" },
-        "Karapürçek": { baseId: "appngTzrsiNEo3rIN", tablo: "Tablo2" },
-        "Edirköy": { baseId: "appngTzrsiNEo3rIN", tablo: "Tablo3" },
-        "Kavacık": { baseId: "appngTzrsiNEo3rIN", tablo: "Tablo4" }
+        "Yuvalı": { tablo: "Tablo1" },
+        "Karapürçek": { tablo: "Tablo2" },
+        "Edirköy": { tablo: "Tablo3" },
+        "Kavacık": { tablo: "Tablo4" }
       },
       MUSTAHSIL_LISTESI: {
         "Yuvalı": ["Ayhan Yüksel","Süleyman Anlar","Engin Çıcan","Selahattin Arslan","Nusret Keskin","Gökhan Keskin","Ahmet Gökgöz","Hüsnü Egen","İsmail Atabey","Emine Atabey","Berrin Batı","Bayram Ali Gürbüz","Şükrüye Can","İbrahim Duraklı","Mehmet Bayraktar","Kemal Erçık","Mithat Acar","Nejat Günan","Ayşe Yalçın","Bilgin Keskin","Nevin Ercan","Süleyman Boylu","Ayşe Yüksel","Ercan Gözüaçık"],
@@ -444,8 +444,8 @@
     
     // Airtable kayıt fonksiyonu
     async function airtableKaydet(formData) {
-      const { baseId, tablo } = CONFIG.TABLO_YAPISI[formData.koy];
-      const url = `/.netlify/functions/airtable?baseId=${baseId}&table=${encodeURIComponent(tablo)}`;
+      const { tablo } = CONFIG.TABLO_YAPISI[formData.koy];
+      const url = `/.netlify/functions/airtable?table=${encodeURIComponent(tablo)}`;
       
       const veri = {
         records: [{

--- a/netlify/functions/airtable.js
+++ b/netlify/functions/airtable.js
@@ -1,14 +1,17 @@
+const BASE_ID = process.env.AIRTABLE_BASE_ID || 'appngTzrsiNEo3rIN';
+
 exports.handler = async function(event) {
   const { httpMethod, queryStringParameters } = event;
-  const { baseId, table, recordId, offset, pageSize } = queryStringParameters;
+  const { table, recordId, offset, pageSize } = queryStringParameters;
 
-  if (!baseId || !table) {
+  if (!table) {
     return {
       statusCode: 400,
-      body: JSON.stringify({ error: 'baseId and table are required' })
+      body: JSON.stringify({ error: 'table is required' })
     };
   }
 
+  const baseId = queryStringParameters.baseId || BASE_ID;
   let url = `https://api.airtable.com/v0/${baseId}/${encodeURIComponent(table)}`;
   if (recordId) {
     url += `/${recordId}`;

--- a/raporlar.html
+++ b/raporlar.html
@@ -355,10 +355,10 @@
 
     const CONFIG = {
       TABLO_YAPISI: {
-        "Yuvalı": { baseId: "appngTzrsiNEo3rIN", tablo: "Tablo1" },
-        "Karapürçek": { baseId: "appngTzrsiNEo3rIN", tablo: "Tablo2" },
-        "Edirköy": { baseId: "appngTzrsiNEo3rIN", tablo: "Tablo3" },
-        "Kavacık": { baseId: "appngTzrsiNEo3rIN", tablo: "Tablo4" }
+        "Yuvalı": { tablo: "Tablo1" },
+        "Karapürçek": { tablo: "Tablo2" },
+        "Edirköy": { tablo: "Tablo3" },
+        "Kavacık": { tablo: "Tablo4" }
       }
     };
 
@@ -384,10 +384,10 @@
     async function airtableVerileriniYukle() {
       try {
         const tumVeriler = [];
-        for (const [koy, { baseId, tablo }] of Object.entries(CONFIG.TABLO_YAPISI)) {
+        for (const [koy, { tablo }] of Object.entries(CONFIG.TABLO_YAPISI)) {
           let offset = "";
           do {
-            const url = `/.netlify/functions/airtable?baseId=${baseId}&table=${encodeURIComponent(tablo)}&pageSize=100${offset ? `&offset=${offset}` : ""}`;
+            const url = `/.netlify/functions/airtable?table=${encodeURIComponent(tablo)}&pageSize=100${offset ? `&offset=${offset}` : ""}`;
             const yanit = await fetch(url);
             const data = await yanit.json();
             data.records.forEach(rec => {
@@ -583,10 +583,10 @@
 
       const recId = id.split('-')[0];
       const ogunAlan = id.endsWith('-S') ? 'Sabah Süt (L)' : 'Akşam Süt (L)';
-      const { baseId, tablo } = CONFIG.TABLO_YAPISI[mevcut.koy] || {};
-      if (!baseId || !tablo) return;
+      const { tablo } = CONFIG.TABLO_YAPISI[mevcut.koy] || {};
+      if (!tablo) return;
       try {
-        await fetch(`/.netlify/functions/airtable?baseId=${baseId}&table=${encodeURIComponent(tablo)}&recordId=${recId}`, {
+        await fetch(`/.netlify/functions/airtable?table=${encodeURIComponent(tablo)}&recordId=${recId}`, {
           method: 'PATCH',
           headers: {
             'Content-Type': 'application/json'


### PR DESCRIPTION
## Summary
- Read Airtable base ID from an environment variable in the Netlify function
- Drop base ID exposure in `index.html` and `raporlar.html`, only passing table name
- Document new `AIRTABLE_PAT` and `AIRTABLE_BASE_ID` environment variables

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689af358e794832b858557a5f42afc5b