### PR TITLE
Fix Airtable function to prevent 502 errors

### DIFF
--- a/netlify/functions/airtable.js
+++ b/netlify/functions/airtable.js
@@ -1,9 +1,8 @@
 const BASE_ID = process.env.AIRTABLE_BASE_ID || 'appngTzrsiNEo3rIN';
 
-exports.handler = async function(event) {
+exports.handler = async function (event) {
   const { httpMethod, queryStringParameters = {} } = event;
-  const { httpMethod, queryStringParameters } = event;
-  const { table, recordId, offset, pageSize } = queryStringParameters;
+  const { table, recordId, offset, pageSize, baseId } = queryStringParameters;
 
   if (!table) {
     return {
@@ -12,9 +11,8 @@ exports.handler = async function(event) {
     };
   }
 
-  let url = `https://api.airtable.com/v0/${BASE_ID}/${encodeURIComponent(table)}`;
-  const baseId = queryStringParameters.baseId || BASE_ID;
-  let url = `https://api.airtable.com/v0/${baseId}/${encodeURIComponent(table)}`;
+  const resolvedBaseId = baseId || BASE_ID;
+  let url = `https://api.airtable.com/v0/${resolvedBaseId}/${encodeURIComponent(table)}`;
   if (recordId) {
     url += `/${recordId}`;
   }


### PR DESCRIPTION
## Summary
- Clean up Airtable Netlify function by removing duplicate variable declarations
- Add support for custom base ID and simplify URL generation

## Testing
- `node -e "require('./SutTakipSistemi/netlify/functions/airtable.js'); console.log('loaded');"`
- `npm test` (fails: Could not read package.json)

------
https://chatgpt.com/codex/tasks/task_e_689b1c21254c832b8cd75406e0307a71