### PR TITLE
Configure node-fetch and Node 18 for Netlify function

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,4 @@
+[functions]
+  node_bundler = "esbuild"
+  node_version = "18"
+

--- a/netlify/functions/airtable.js
+++ b/netlify/functions/airtable.js
@@ -1,3 +1,4 @@
+const fetch = require('node-fetch');
 const https = require('https');
 
 const BASE_ID = process.env.AIRTABLE_BASE_ID || 'appngTzrsiNEo3rIN';

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "sut-takip-sistemi",
+  "version": "1.0.0",
+  "dependencies": {
+    "node-fetch": "^3"
+  }
+}
+


### PR DESCRIPTION
## Summary
- require `node-fetch` in Airtable Netlify function
- add `package.json` with `node-fetch` dependency
- set Netlify functions to Node 18 with esbuild bundler

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_689b24598658832b9b5db4e736c50d06