### PR TITLE
Add global error handling system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@ _site/
 # counterproductive to check this file into the repository.
 # Details at https://github.com/github/pages-gem/issues/768
 Gemfile.lock
+
+# Node.js artifacts
+node_modules/
+package-lock.json

--- a/index.html
+++ b/index.html
@@ -318,6 +318,7 @@
     📱 Uygulamayı Yükle
   </button>
   
+  <script src="js/errorHandler.js"></script>
   <script>
     // Sabitler ve yapılandırma
     const CONFIG = {
@@ -360,7 +361,7 @@
       if ('serviceWorker' in navigator) {
         navigator.serviceWorker.register('/service-worker.js')
           .then(() => console.log('SW kayıt başarılı'))
-          .catch(err => console.log('SW kayıt hatası:', err));
+          .catch(err => handleAppError(err, 'Service Worker'));
       }
       
       // 15 günlük e-posta kontrolü için timer
@@ -438,7 +439,7 @@
         sistemDurumunuGuncelle();
 
       } catch (err) {
-        gosterMesaj("⚠️ Sunucu hatası: " + err.message, "error");
+        handleAppError(err, 'Veri Kaydetme');
       }
     }
     
@@ -595,7 +596,7 @@
         console.log("✅ 15 günlük rapor otomatik olarak gönderildi");
 
       } catch (error) {
-        console.error("❌ Otomatik e-posta gönderim hatası:", error);
+        handleAppError(error, 'Otomatik E-posta');
       }
     }
     
@@ -606,7 +607,7 @@
         await emailGonder(rapor, true);
         gosterMesaj("✅ Test e-postası gönderildi!", "success");
       } catch (error) {
-        gosterMesaj("❌ E-posta gönderim hatası: " + error.message, "error");
+        handleAppError(error, 'Test E-posta');
       }
     }
     

--- a/js/errorHandler.js
+++ b/js/errorHandler.js
@@ -1,0 +1,24 @@
+(function() {
+  function showMessage(msg) {
+    const container = document.getElementById('durum');
+    if (!container) return;
+    container.innerHTML = `<div class="status-message status-error">${msg}</div>`;
+    setTimeout(() => (container.innerHTML = ''), 5000);
+  }
+
+  function logError(err, context = 'Genel') {
+    const message = err && err.message ? err.message : String(err);
+    console.error(`Hata [${context}]:`, err);
+    showMessage(`Beklenmeyen bir hata oluştu (${context}): ${message}`);
+  }
+
+  window.addEventListener('error', (event) => {
+    logError(event.error || event.message, 'Pencere');
+  });
+
+  window.addEventListener('unhandledrejection', (event) => {
+    logError(event.reason, 'Promise');
+  });
+
+  window.handleAppError = logError;
+})();

--- a/netlify/functions/airtable.js
+++ b/netlify/functions/airtable.js
@@ -1,90 +1,87 @@
-const fetch = require('node-fetch');
 const https = require('https');
 
-const BASE_ID = process.env.AIRTABLE_BASE_ID || 'appngTzrsiNEo3rIN';
+const DEFAULT_BASE_ID = process.env.AIRTABLE_BASE_ID || 'appngTzrsiNEo3rIN';
 const TOKEN = process.env.AIRTABLE_PAT;
 
 exports.handler = async function(event) {
-  const { httpMethod, queryStringParameters = {} } = event;
-  const { table, recordId, offset, pageSize } = queryStringParameters;
+  try {
+    const { httpMethod, queryStringParameters = {} } = event;
+    const { table, recordId, offset, pageSize, baseId } = queryStringParameters;
 
-  if (!TOKEN) {
-    return {
-      statusCode: 500,
-      body: JSON.stringify({ error: 'AIRTABLE_PAT not configured' })
+    if (!TOKEN) {
+      return {
+        statusCode: 500,
+        body: JSON.stringify({ error: 'AIRTABLE_PAT not configured' })
+      };
+    }
+
+    if (!table) {
+      return {
+        statusCode: 400,
+        body: JSON.stringify({ error: 'table is required' })
+      };
+    }
+
+    const resolvedBaseId = baseId || DEFAULT_BASE_ID;
+    let path = `/v0/${resolvedBaseId}/${encodeURIComponent(table)}`;
+    if (recordId) {
+      path += `/${recordId}`;
+    }
+
+    const params = new URLSearchParams();
+    if (offset) params.append('offset', offset);
+    if (pageSize) params.append('pageSize', pageSize);
+    const qs = params.toString();
+    if (qs) path += `?${qs}`;
+
+    const body = (httpMethod !== 'GET' && httpMethod !== 'HEAD') ? (event.body || '') : null;
+
+    const headers = {
+      Authorization: `Bearer ${TOKEN}`,
+      'Content-Type': 'application/json'
     };
-  }
-const BASE_ID = process.env.AIRTABLE_BASE_ID || 'appngTzrsiNEo3rIN';
+    if (body) {
+      headers['Content-Length'] = Buffer.byteLength(body);
+    }
 
-exports.handler = async function (event) {
-  const { httpMethod, queryStringParameters = {} } = event;
-  const { table, recordId, offset, pageSize, baseId } = queryStringParameters;
-
-
-  if (!table) {
-    return {
-      statusCode: 400,
-      body: JSON.stringify({ error: 'table is required' })
+    const options = {
+      method: httpMethod,
+      hostname: 'api.airtable.com',
+      path,
+      headers
     };
-  }
 
-  let path = `/v0/${BASE_ID}/${encodeURIComponent(table)}`;
-
-  const resolvedBaseId = baseId || BASE_ID;
-  let url = `https://api.airtable.com/v0/${resolvedBaseId}/${encodeURIComponent(table)}`;
-  if (recordId) {
-    path += `/${recordId}`;
-  }
-
-  const params = new URLSearchParams();
-  if (offset) params.append('offset', offset);
-  if (pageSize) params.append('pageSize', pageSize);
-  const qs = params.toString();
-  if (qs) path += `?${qs}`;
-
-  const body = (httpMethod !== 'GET' && httpMethod !== 'HEAD') ? (event.body || '') : null;
-
-  const headers = {
-    'Authorization': `Bearer ${TOKEN}`,
-    'Content-Type': 'application/json'
-  };
-
-  if (body) {
-    headers['Content-Length'] = Buffer.byteLength(body);
-  }
-
-  const options = {
-    method: httpMethod,
-    hostname: 'api.airtable.com',
-    path,
-    headers
-  };
-
-  return new Promise(resolve => {
-    const req = https.request(options, res => {
-      let data = '';
-      res.on('data', chunk => data += chunk);
-      res.on('end', () => {
-        resolve({
-          statusCode: res.statusCode,
-          headers: {
-            'Content-Type': res.headers['content-type'] || 'application/json'
-          },
-          body: data
+    return await new Promise((resolve) => {
+      const req = https.request(options, (res) => {
+        let data = '';
+        res.on('data', (chunk) => (data += chunk));
+        res.on('end', () => {
+          resolve({
+            statusCode: res.statusCode,
+            headers: {
+              'Content-Type': res.headers['content-type'] || 'application/json'
+            },
+            body: data
+          });
         });
       });
-    });
 
-    req.on('error', err => {
-      resolve({
-        statusCode: 500,
-        body: JSON.stringify({ error: err.message })
+      req.on('error', (err) => {
+        resolve({
+          statusCode: 500,
+          body: JSON.stringify({ error: err.message })
+        });
       });
-    });
 
-    if (body) {
-      req.write(body);
-    }
-    req.end();
-  });
+      if (body) {
+        req.write(body);
+      }
+      req.end();
+    });
+  } catch (err) {
+    return {
+      statusCode: 500,
+      body: JSON.stringify({ error: err.message || String(err) })
+    };
+  }
 };


### PR DESCRIPTION
## Summary
- Add reusable errorHandler script to capture uncaught errors and promise rejections
- Use centralized error handler across client code for service worker, data save, and email operations
- Refactor Airtable Netlify function with robust input validation and try/catch

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689b2a094c18832b8f105e453c5292fa