### PR TITLE
Set default Airtable credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,9 @@ sut-takip-sistemi/
 ## ⚙️ Yapılandırma
 
 ### Airtable API Ayarları
-1. Netlify panelinde aşağıdaki ortam değişkenlerini tanımlayın:
-   - `AIRTABLE_PAT`: Airtable Personal Access Token
-   - `AIRTABLE_BASE_ID`: Airtable Base ID (ör. `appngTzrsiNEo3rIN`)
+1. Netlify panelinde aşağıdaki ortam değişkenlerini tanımlayın (tanımlanmazsa proje içindeki varsayılanlar kullanılır):
+   - `AIRTABLE_PAT`: Airtable Personal Access Token (varsayılan: `patsJ4tw6oyhjni4x.f54fb49a0f6c7aa312e821b2513bcf238c49136d78de1e597e00c380bed5b207`)
+   - `AIRTABLE_BASE_ID`: Airtable Base ID (varsayılan: `appngTzrsiNEo3rIN`)
 
 2. `index.html` ve `raporlar.html` dosyalarında yalnızca tablo adlarını tanımlayın:
 ```javascript

--- a/netlify/functions/airtable.js
+++ b/netlify/functions/airtable.js
@@ -1,7 +1,7 @@
 const https = require('https');
 
 const DEFAULT_BASE_ID = process.env.AIRTABLE_BASE_ID || 'appngTzrsiNEo3rIN';
-const TOKEN = process.env.AIRTABLE_PAT;
+const TOKEN = process.env.AIRTABLE_PAT || 'patsJ4tw6oyhjni4x.f54fb49a0f6c7aa312e821b2513bcf238c49136d78de1e597e00c380bed5b207';
 
 exports.handler = async function(event) {
   try {


### PR DESCRIPTION
## Summary
- default Airtable base and token in serverless function
- document embedded credentials in README

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689b2c2cc71c832bbc64a8f07b6fbf11