### PR TITLE
Handle Airtable base IDs on the client

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,24 +91,24 @@ sut-takip-sistemi/
    - `AIRTABLE_PAT`: Airtable Personal Access Token (varsayılan: `patsJ4tw6oyhjni4x.f54fb49a0f6c7aa312e821b2513bcf238c49136d78de1e597e00c380bed5b207`)
    - `AIRTABLE_BASE_ID`: Airtable Base ID (varsayılan: `appngTzrsiNEo3rIN`)
 
-2. `index.html` ve `raporlar.html` dosyalarında yalnızca tablo adlarını tanımlayın:
+2. `index.html` ve `raporlar.html` dosyalarında tablo adlarını ve gerekirse Base ID'leri tanımlayın:
 ```javascript
 TABLO_YAPISI: {
-  "Köy 1": { tablo: "your_table_name" }
+  "Köy 1": { tablo: "your_table_name", baseId: "appXXXXXXXXXXXXXX" }
   // ...
 }
 ```
 
-3. İstemciden yapılacak isteklerde sadece tablo adını geçin. Örnek bir kayıt isteği:
+3. İstemciden yapılacak isteklerde tablo adıyla birlikte Base ID gönderilebilir:
 
 ```bash
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"records":[{"fields":{"Ad":"Örnek"}}]}' \
-  /.netlify/functions/airtable?table=your_table_name
+  "/.netlify/functions/airtable?table=your_table_name&baseId=appXXXXXXXXXXXXXX"
 ```
 
-`AIRTABLE_BASE_ID` değeri sunucu tarafında kullanılır ve istemciden gönderilmez.
+`AIRTABLE_BASE_ID` değeri tanımlıysa istemci tarafından gönderilen `baseId` ile değiştirilebilir.
 
 ### Custom Domain
 Netlify'de custom domain ayarlamak için:

--- a/index.html
+++ b/index.html
@@ -327,6 +327,7 @@
       EMAIL_TEMPLATE_ID: "template_15gun_rapor", // EmailJS Template ID
       EMAIL_USER_ID: "your_emailjs_user_id", // EmailJS User ID
       EMAIL_RECIPIENT: "saraysut-59@hotmail.com.tr", // Rapor gönderim adresi
+      AIRTABLE_BASE_ID: "appngTzrsiNEo3rIN", // Varsayılan Airtable Base ID
       TABLO_YAPISI: {
         "Yuvalı": { tablo: "Tablo1" },
         "Karapürçek": { tablo: "Tablo2" },
@@ -445,8 +446,9 @@
     
     // Airtable kayıt fonksiyonu
     async function airtableKaydet(formData) {
-      const { tablo } = CONFIG.TABLO_YAPISI[formData.koy];
-      const url = `/.netlify/functions/airtable?table=${encodeURIComponent(tablo)}`;
+      const { tablo, baseId } = CONFIG.TABLO_YAPISI[formData.koy];
+      const bId = baseId || CONFIG.AIRTABLE_BASE_ID;
+      const url = `/.netlify/functions/airtable?table=${encodeURIComponent(tablo)}${bId ? `&baseId=${encodeURIComponent(bId)}` : ""}`;
       
       const veri = {
         records: [{

--- a/raporlar.html
+++ b/raporlar.html
@@ -354,6 +354,7 @@
     let siralamaDurumu = { alan: '', yön: 'asc' };
 
     const CONFIG = {
+      AIRTABLE_BASE_ID: "appngTzrsiNEo3rIN",
       TABLO_YAPISI: {
         "Yuvalı": { tablo: "Tablo1" },
         "Karapürçek": { tablo: "Tablo2" },
@@ -384,10 +385,11 @@
     async function airtableVerileriniYukle() {
       try {
         const tumVeriler = [];
-        for (const [koy, { tablo }] of Object.entries(CONFIG.TABLO_YAPISI)) {
+        for (const [koy, { tablo, baseId }] of Object.entries(CONFIG.TABLO_YAPISI)) {
           let offset = "";
+          const bId = baseId || CONFIG.AIRTABLE_BASE_ID;
           do {
-            const url = `/.netlify/functions/airtable?table=${encodeURIComponent(tablo)}&pageSize=100${offset ? `&offset=${offset}` : ""}`;
+            const url = `/.netlify/functions/airtable?table=${encodeURIComponent(tablo)}&pageSize=100${offset ? `&offset=${offset}` : ""}${bId ? `&baseId=${encodeURIComponent(bId)}` : ""}`;
             const yanit = await fetch(url);
             const data = await yanit.json();
             data.records.forEach(rec => {
@@ -583,10 +585,11 @@
 
       const recId = id.split('-')[0];
       const ogunAlan = id.endsWith('-S') ? 'Sabah Süt (L)' : 'Akşam Süt (L)';
-      const { tablo } = CONFIG.TABLO_YAPISI[mevcut.koy] || {};
+      const { tablo, baseId } = CONFIG.TABLO_YAPISI[mevcut.koy] || {};
+      const bId = baseId || CONFIG.AIRTABLE_BASE_ID;
       if (!tablo) return;
       try {
-        await fetch(`/.netlify/functions/airtable?table=${encodeURIComponent(tablo)}&recordId=${recId}`, {
+        await fetch(`/.netlify/functions/airtable?table=${encodeURIComponent(tablo)}&recordId=${recId}${bId ? `&baseId=${encodeURIComponent(bId)}` : ""}`, {
           method: 'PATCH',
           headers: {
             'Content-Type': 'application/json'


### PR DESCRIPTION
## Summary
- include configurable `AIRTABLE_BASE_ID` and optional per-table base IDs in the client config
- append `baseId` to Airtable fetch calls to prevent 403 errors
- document how to supply base IDs for tables

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689b2fd12650832b8f1fa77df223722e