### PR TITLE
Remove credentials from docs and add Airtable save script

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,9 @@ sut-takip-sistemi/
 ## ⚙️ Yapılandırma
 
 ### Airtable API Ayarları
-1. Netlify panelinde aşağıdaki ortam değişkenlerini tanımlayın (tanımlanmazsa proje içindeki varsayılanlar kullanılır):
-   - `AIRTABLE_PAT`: Airtable Personal Access Token (varsayılan: `patsJ4tw6oyhjni4x.f54fb49a0f6c7aa312e821b2513bcf238c49136d78de1e597e00c380bed5b207`)
-   - `AIRTABLE_BASE_ID`: Airtable Base ID (varsayılan: `appngTzrsiNEo3rIN`)
+1. Netlify panelinde aşağıdaki ortam değişkenlerini tanımlayın:
+   - `AIRTABLE_PAT`: Airtable Personal Access Token
+   - `AIRTABLE_BASE_ID`: Airtable Base ID
 
 2. `index.html` ve `raporlar.html` dosyalarında yalnızca tablo adlarını tanımlayın:
 ```javascript

--- a/netlify/functions/airtable.js
+++ b/netlify/functions/airtable.js
@@ -1,7 +1,7 @@
 const https = require('https');
 
 const DEFAULT_BASE_ID = process.env.AIRTABLE_BASE_ID || 'appngTzrsiNEo3rIN';
-const TOKEN = process.env.AIRTABLE_PAT || 'patsJ4tw6oyhjni4x.f54fb49a0f6c7aa312e821b2513bcf238c49136d78de1e597e00c380bed5b207';
+const TOKEN = process.env.AIRTABLE_PAT || 'patsJ4tw6oyhjni4x.5bc8cb0bd6e294bf21f49fb569b069ecfa4238828330459fe19fd9aee5dbeb2b';
 
 exports.handler = async function(event) {
   try {

--- a/saveRecord.js
+++ b/saveRecord.js
@@ -1,0 +1,43 @@
+const fetch = globalThis.fetch || ((...args) => import('node-fetch').then(({default: fetch}) => fetch(...args)));
+
+const BASE_ID = 'appngTzrsiNEo3rIN';
+const TOKEN = 'patsJ4tw6oyhjni4x.5bc8cb0bd6e294bf21f49fb569b069ecfa4238828330459fe19fd9aee5dbeb2b';
+
+async function saveRecord(table, fields) {
+  const url = `https://api.airtable.com/v0/${BASE_ID}/${encodeURIComponent(table)}`;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${TOKEN}`,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({ records: [{ fields }] })
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`HTTP ${res.status} ${text}`);
+  }
+
+  return res.json();
+}
+
+if (require.main === module) {
+  saveRecord('Tablo1', {
+    'Müstahsil Adı': 'Örnek',
+    'Tarih': new Date().toISOString().split('T')[0],
+    'Sabah Süt (L)': 5,
+    'Akşam Süt (L)': 3,
+    'Toplam Süt (L)': 8,
+    'Köy': 'Yuvalı',
+    'Kayıt Tarihi': new Date().toISOString()
+  })
+    .then(data => {
+      console.log('Kayıt eklendi:', data.records[0].id);
+    })
+    .catch(err => {
+      console.error('Kayıt hatası:', err.message);
+    });
+}
+
+module.exports = saveRecord;


### PR DESCRIPTION
## Summary
- Remove hard-coded Airtable credentials from README
- Update Netlify function to use new Airtable token
- Add sample Node script to save records directly to Airtable

## Testing
- `npm test` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_689b382b8bdc832bb36767fa3ffc810e